### PR TITLE
refactor: Implement targeted DOM updates for task operations

### DIFF
--- a/js/modules/search-manager.js
+++ b/js/modules/search-manager.js
@@ -34,7 +34,7 @@ class SearchManager {
       input.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
           input.value = '';
-          this.taskManager.renderAllTasks();
+          this.taskManager.searchTasks(''); // Clears the search term and renders filtered (all) tasks
         }
       });
     };


### PR DESCRIPTION
This commit significantly refactors the rendering logic in TaskManager to improve performance and your experience by avoiding unnecessary full re-renders of task lists.

Key changes:

- TaskManager.saveTasks() no longer calls renderAllTasks(). It now primarily handles saving data to localStorage and applying task styling.
- Methods like addTask(), updateTask(), and deleteTask() in TaskManager have been updated to perform targeted DOM manipulations:
    - addTask() now appends only the new task element.
    - updateTask() now re-renders only the specific task element that was changed.
    - deleteTask() now removes only the specific task element.
- Methods for modifying parts of a task (addSubtask, editSubtask, etc.) in TaskManager also re-render only the affected parent task card to update progress displays.
- initializeDefaultTasksForUser() and sortTasks() in TaskManager now explicitly call renderAllTasks() as a full refresh is appropriate in these cases.
- DragDropManager.js drop handling and TaskManager.js touchend logic for touch drag were reviewed and updated to ensure they correctly manage DOM state before calling the modified saveTasks().
- SearchManager.js Escape key behavior now calls taskManager.searchTasks('') for consistency, which uses renderFilteredTasks().
- renderFilteredTasks() remains as is for now, clearing and re-rendering columns based on filtered tasks, which is acceptable for search functionality.

These changes aim to make the application more responsive, especially when dealing with task manipulations on boards with many tasks, by reducing the scope of DOM updates to only what is necessary.