### PR TITLE
refactor: Remove global window.boardManager dependency

### DIFF
--- a/js/broadify.js
+++ b/js/broadify.js
@@ -15,7 +15,8 @@ class Boardify {
 
     // Initialize application modules, passing userId where needed.
     this.boardManager = new BoardManager(this.userId);
-    this.taskManager = new TaskManager(this.userId); // TaskManager is created with userId
+    // Pass boardManager to TaskManager constructor
+    this.taskManager = new TaskManager(this.userId, this.boardManager);
     
     // Now that taskManager is initialized with userId, ensure default tasks are set up.
     // This is crucial for new users or guest sessions.
@@ -40,7 +41,7 @@ class Boardify {
     // that currently uses window.boardManager. This should be refactored in the future
     // to avoid global access, perhaps by passing boardManager instance or relevant board data
     // to taskManager more directly when needed.
-    window.boardManager = this.boardManager; 
+    // window.boardManager = this.boardManager; // Removed global assignment
 
     // Create a placeholder element for task drag-and-drop interactions.
     this.taskPlaceholder = document.createElement('div');

--- a/js/modules/task-manager.js
+++ b/js/modules/task-manager.js
@@ -7,8 +7,9 @@ import { defaultTasks } from './constants'; // Import defaultTasks
  * deletion, searching, rendering, and sorting of tasks.
  */
 class TaskManager {
-  constructor(userId) { // Accept userId
+  constructor(userId, boardManager) { // Accept userId and boardManager
     this.userId = userId;
+    this.boardManager = boardManager; // Store boardManager instance
     this.tasksKey = this.userId ? `tasks_${this.userId}` : 'tasks_guest'; // tasks_guest for null userId
 
     // Load tasks from localStorage or initialize with an empty array.
@@ -499,7 +500,7 @@ class TaskManager {
 
     // Due date styling
     let isOverdue = false; // This will determine the text color of the due date
-    const boardManager = window.boardManager; // Access boardManager globally for column titles
+    const boardManager = this.boardManager; // Access boardManager via instance property
 
     // Remove any existing due date styling classes first to handle updates correctly
     taskElement.classList.remove(


### PR DESCRIPTION
This commit refactors TaskManager and Boardify to eliminate the global `window.boardManager` variable. TaskManager now receives an instance of BoardManager via constructor injection.

Key changes:

- Modified `TaskManager` constructor to accept `boardManager` as an argument and store it as `this.boardManager`.
- Updated `TaskManager.renderTask()` to use `this.boardManager` instead of `window.boardManager` for accessing board-related information (e.g., checking if a task's column is a 'Done' column).
- Updated `Boardify` constructor to pass the `boardManager` instance to the `TaskManager` constructor during instantiation.
- Removed the line `window.boardManager = this.boardManager;` from `Boardify.js`.

This change improves code modularity, testability, and maintainability by making dependencies explicit and reducing reliance on global state.