### PR TITLE
feat: Implement drag-and-drop board reordering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -67,3 +67,11 @@
     /* Styles for when modal is shown */
   }
 }
+
+/* Styling for the board being dragged */
+.dragging-board {
+  opacity: 0.6;
+  border: 2px solid #4f46e5; /* Example: Indigo-600 focus color */
+  transform: scale(0.98); /* Slightly shrink */
+  transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+}


### PR DESCRIPTION
This commit introduces the ability for you to reorder Kanban boards via drag-and-drop.

Key changes:

1.  **Board Draggability:**
    - In `BoardManager.renderBoards()`, board elements are now made `draggable` and store their `data-board-index`.
    - A class `board-draggable-item` is added for styling/selection.

2.  **Board Drag Event Listeners (`BoardManager.js`):**
    - `dragstart`: Initiates when dragging a board. It sets `dataTransfer` with the board's index (using custom type `application/boardify-board-index`) and applies a `.dragging-board` class for visual feedback. Logic added to prevent drag if starting on interactive elements within the board (header buttons, tasks).
    - `dragend`: Cleans up by removing the `.dragging-board` class and any stray board drop placeholders.

3.  **Drop Zone Logic on Main Board Container (`BoardManager.js`):**
    - A `board-drop-placeholder` element is created and styled to indicate valid drop locations.
    - `initializeBoardDragDropListeners()` sets up listeners on the main boards container (`.board`):
        - `dragenter`: Allows drop if a board is being dragged.
        - `dragover`: Manages the positioning of the `boardDropPlaceholder` based on cursor position, determining which existing board the placeholder should appear before. - `dragleave`: Removes the placeholder if the drag leaves the container. - `drop`: Handles the core reordering:
            - Retrieves the `draggedBoardIndex`.
            - Determines the `targetDropIndex` based on the drop location. - **Board Array Update:** Reorders the `this.boards` array by splicing the dragged board out and inserting it at the target index. - `saveBoards()` is called. - **Task Column Index Remapping:** Iterates through all tasks (`taskManager.tasks`). For each task, its `column` property (which is an index) is updated to reflect the new index of its parent board in the reordered `boards` array. This critical step ensures tasks remain correctly associated with their boards. - `taskManager.saveTasks()` is called. - `renderBoards()` is called to refresh the UI with the new board order and correctly mapped tasks.

4.  **Visual Feedback and Styling:**
    - Added CSS for the `.dragging-board` class in `style.css` (opacity, border, transform) for clear visual indication of the dragged board.
    - Updated the styling of `board-drop-placeholder` in `BoardManager.js` (using Tailwind classes) to better match board dimensions and include "Drop here" text.

5.  **Auto-Scrolling:**
    - Verified that the existing global auto-scroll mechanism (in `Boardify.js` calling `DragDropManager.autoScrollOnDrag`) correctly scrolls the main board container horizontally when dragging a board near the edges.

This feature significantly enhances board management by allowing you to customize the order of your boards to suit your workflow. The implementation includes robust data updates for both board order and task associations.