### PR TITLE
fix: Correct syntax error in Boardify.js attachGlobalEvents

### DIFF
--- a/js/broadify.js
+++ b/js/broadify.js
@@ -131,7 +131,7 @@ class Boardify {
         reader.readAsText(file);
       });
     }
-    }
+    // Removed extra closing brace here
   }
 
   importData(jsonData) {


### PR DESCRIPTION
This commit fixes a JavaScript syntax error in the `attachGlobalEvents` method within the `Boardify` class (`js/broadify.js`). An extraneous closing curly brace was inadvertently added during the implementation of event listeners for the data import feature.

This error caused the subsequent methods (importData, exportData, handleKeyboardShortcuts, etc.) to be defined outside the class scope, leading to a parsing failure during the Vite/Rollup build process, as reported in the Docker build logs.

Removing the extra brace corrects the class structure and resolves the build failure.