### PR TITLE
feat: Setup Playwright for End-to-End Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ Thumbs.db
 *.tfstate.*
 .terraform/
 .terraform.lock.hcl
+
+# Playwright E2E testing output
+playwright-report/
+test-results/

--- a/e2e/board-and-task-creation.spec.js
+++ b/e2e/board-and-task-creation.spec.js
@@ -1,0 +1,74 @@
+// e2e/board-and-task-creation.spec.js
+import { test, expect } from '@playwright/test';
+
+test.describe('Board and Task Creation Flow', () => {
+  const newBoardName = 'My E2E Test Board';
+  const newTaskTitle = 'First E2E Task';
+
+  test.beforeEach(async ({ page }) => {
+    // Go to the home page before each test
+    await page.goto('/');
+    // Clear localStorage for a clean state before each test in this describe block
+    await page.evaluate(() => localStorage.clear());
+    // Reload to apply the cleared localStorage
+    await page.reload();
+     // It might take a moment for localStorage to actually clear and UI to reset.
+    // A small wait or check for an element that indicates a clear state might be needed
+    // if tests are flaky. For now, simple reload.
+  });
+
+  test('should allow a user to create a new board and add a task to it', async ({ page }) => {
+    // 1. Assert Page Title
+    await expect(page).toHaveTitle(/Boardify/);
+
+    // 2. Handle the prompt for board name and create a new board
+    page.on('dialog', async dialog => {
+      expect(dialog.type()).toContain('prompt');
+      expect(dialog.message()).toContain('Enter the name of the new board:');
+      await dialog.accept(newBoardName);
+    });
+
+    // Click "Add New Board" button
+    // Assuming the button is initially visible, otherwise wait for it.
+    const addNewBoardBtn = page.locator('#add-new-board-btn');
+    await expect(addNewBoardBtn).toBeVisible();
+    await addNewBoardBtn.click();
+
+    // 3. Verify the new board appears on the screen
+    // Boards are rendered dynamically. We'll look for the board by its title within an h3.
+    // The board header h3 has a class 'board-title-heading' from previous work.
+    const newBoardHeader = page.locator(`.board-draggable-item .board-title-heading`, { hasText: newBoardName });
+    await expect(newBoardHeader).toBeVisible({ timeout: 10000 }); // Increased timeout for dynamic element
+
+    // Find the specific board container for the new board to scope task creation
+    const newBoardContainer = page.locator(`.board-draggable-item:has(h3.board-title-heading:has-text("${newBoardName}"))`);
+    await expect(newBoardContainer).toBeVisible();
+
+    // 4. Click the "Add Task" button within that specific new board
+    const addTaskBtnInNewBoard = newBoardContainer.locator('.add-task-btn');
+    await expect(addTaskBtnInNewBoard).toBeVisible();
+    await addTaskBtnInNewBoard.click();
+
+    // 5. Fill out the task title in the task modal
+    const taskModal = page.locator('#task-modal');
+    await expect(taskModal).toBeVisible();
+
+    const taskTitleInput = taskModal.locator('#task-title');
+    await expect(taskTitleInput).toBeVisible();
+    await taskTitleInput.fill(newTaskTitle);
+
+    // 6. Click "Save Task" in the modal
+    // The submit button is type="submit"
+    const saveTaskBtn = taskModal.locator('button[type="submit"]');
+    await expect(saveTaskBtn).toBeVisible();
+    await saveTaskBtn.click();
+
+    // 7. Assert that the task modal is hidden
+    await expect(taskModal).toBeHidden();
+
+    // 8. Verify the new task appears in the new board's column
+    // Tasks are divs with class 'task'. We'll look for one containing the title.
+    const newTaskCard = newBoardContainer.locator(`.task h4:has-text("${newTaskTitle}")`);
+    await expect(newTaskCard).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "build": "vite build",
     "preview": "vite preview",
     "format": "prettier --write .",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,80 @@
+// playwright.config.js
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './e2e', // Directory where E2E test files are located
+
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html', // Generates a nice HTML report of test results
+
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:5173', // Make sure this matches your dev server URL
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry', // Other options: 'retain-on-failure', 'on', 'off'
+
+    /* Capture screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Capture video on failure */
+    video: 'retain-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // Optionally, configure Firefox and WebKit for cross-browser testing
+    /*
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    */
+
+    /* Example for mobile viewports - useful for responsive design testing */
+    /*
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+    */
+  ],
+
+  /* Optional: Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'pnpm dev', // Command to start your dev server
+  //   url: 'http://localhost:5173', // URL to wait for before tests start
+  //   reuseExistingServer: !process.env.CI, // Reuse server if already running locally
+  //   timeout: 120 * 1000, // Timeout for server to start
+  // },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^4.0.11
         version: 4.0.11
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.52.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.15.21)
@@ -436,6 +439,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@playwright/test@1.52.0':
+    resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.40.1':
     resolution: {integrity: sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw==}
@@ -892,6 +900,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1345,6 +1358,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -2106,6 +2129,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@playwright/test@1.52.0':
+    dependencies:
+      playwright: 1.52.0
+
   '@rollup/rollup-android-arm-eabi@4.40.1':
     optional: true
 
@@ -2547,6 +2574,9 @@ snapshots:
       path-exists: 4.0.0
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3120,6 +3150,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.3:
     dependencies:


### PR DESCRIPTION
This commit introduces Playwright for End-to-End (E2E) testing into your project. It includes the initial setup, configuration, and a first test case for a core user flow.

Key changes:

1.  **Dependencies:**
    - Added `@playwright/test` as a dev dependency.
    - Browser binaries (Chromium, Firefox, WebKit) are expected to be installed via `pnpm exec playwright install`.

2.  **Configuration (`playwright.config.js`):**
    - Created `playwright.config.js` in the project root.
    - Configured `testDir` to `./e2e`.
    - Set `baseURL` to `http://localhost:5173` (for local dev server).
    - Enabled HTML reporter (`reporter: 'html'`).
    - Configured trace collection (`on-first-retry`), screenshots, and videos on failure.
    - Set up a default project for Chromium.

3.  **`package.json` Script:**
    - Added a new script: `"test:e2e": "playwright test"` for running E2E tests.

4.  **Test Structure:**
    - Created an `e2e/` directory in the project root.
    - Added an initial test file: `e2e/board-and-task-creation.spec.js`.

5.  **First E2E Test (`board-and-task-creation.spec.js`):**
    - Implemented a test suite for "Board and Task Creation Flow".
    - Includes a `beforeEach` hook to clear `localStorage` and reload the page for a clean test environment.
    - The test covers:
        - Navigating to the application's base URL.
        - Asserting the page title. - Creating a new board by interacting with the browser's `prompt` dialog (via `page.on('dialog', ...)`). - Verifying the new board's visibility. - Adding a new task to the created board through the task modal. - Verifying the new task's visibility within its board.

6.  **`.gitignore` Update:**
    - Added `playwright-report/` and `test-results/` to `.gitignore` to exclude Playwright's output directories.

This setup provides the foundation for building a comprehensive E2E test suite to ensure application stability and identify regressions in user-facing functionality.