### PR TITLE
fix: Refine Docker publish GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,24 +8,39 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Needed if pushing to GHCR, good practice.
+      # id-token: write # Uncomment if using OIDC for auth with cloud providers
+
     steps:
-      # Check out the repository code
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Set up Docker Buildx for advanced build capabilities
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      # Build the Docker image and tag it as latest
-      - name: Build Docker Image
-        run: |
-          docker build -t chintanboghara/boardify:latest .
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Log in to Docker Hub using secrets from repository settings
-      - name: Docker Login
-        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: chintanboghara/boardify # IMPORTANT: Ensure this is the correct Docker Hub username/image name
 
-      # Push the built image to Docker Hub
-      - name: Push Docker Image
-        run: docker push chintanboghara/boardify:latest
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Optional:provenance: false # Set to true or remove to enable, false to disable. Default might be true.
+          # Optional: enable layer caching
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max


### PR DESCRIPTION
Replaces manual docker build, login, and push commands with the official Docker GitHub Actions for improved robustness and maintainability.

The workflow now uses:
- `actions/checkout@v4`
- `docker/setup-buildx-action@v3`
- `docker/login-action@v3` for Docker Hub authentication using secrets.
- `docker/metadata-action@v5` to automatically generate relevant image tags (e.g., latest, git SHA) and labels.
- `docker/build-push-action@v6` to build the Docker image and push it to Docker Hub using the generated tags and labels.

This change aims to resolve potential issues like "missing content-length header" during docker push by leveraging these specialized actions.

Note: You must ensure `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are correctly set in GitHub repository settings, and the `images` field in `docker/metadata-action` correctly targets their Docker Hub repository.